### PR TITLE
Accept proxy options for the IDAM test harness as required

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/div-idam-test-harness",
-  "version": "1.0.13",
+  "version": "1.1.0",
   "description": "Test harness for the IdAM Express Middleware",
   "license": "MIT",
   "main": "src/index.js",
@@ -21,7 +21,8 @@
   "dependencies": {
     "@hmcts/div-idam-express-middleware": "https://github.com/hmcts/div-idam-express-middleware#3.0.4",
     "request": "^2.81.0",
-    "request-promise-native": "^1.0.4"
+    "request-promise-native": "^1.0.4",
+    "socks5-https-client": "^1.0.3"
   },
   "devDependencies": {
     "@hmcts/eslint-config": "^1.4.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,10 @@
 const sinon = require('sinon');
 const request = require('request-promise-native');
 const idamExpress = require('@hmcts/div-idam-express-middleware');
+const socksAgent = require('socks5-https-client/lib/Agent');
+const url = require('url');
+
+const DEFAULT_PORT = 9000;
 
 const onAuthenticate = () => {
   return (req, res, next) => {
@@ -32,7 +36,26 @@ const restore = () => {
   idamExpress.protect.restore();
 };
 
-const createUser = args => {
+const setupProxy = proxy => {
+  const proxyUrl = url.parse(proxy);
+
+  let proxyOptions = {};
+
+  if (proxyUrl.protocol.indexOf('socks') >= 0) {
+    proxyOptions = {
+      strictSSL: false,
+      agentClass: socksAgent,
+      socksHost: proxyUrl.hostname || 'localhost',
+      socksPort: proxyUrl.port || DEFAULT_PORT
+    };
+  } else {
+    proxyOptions = { proxy: proxyUrl.href };
+  }
+
+  return proxyOptions;
+};
+
+const createUser = (args, proxy) => {
   const endpoint = args.accountsEndpoint || '/testing-support/accounts';
   const userGroup = args.testGroupCode || 'divorce-private-beta';
   // Minimum required fields
@@ -44,19 +67,29 @@ const createUser = args => {
     password: args.testPassword || 'passWord123!',
     levelOfAccess: args.testLevelOfAccess || '1'
   };
+
   const options = {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(user)
   };
 
+  if (proxy) {
+    Object.assign(options, setupProxy(proxy));
+  }
+
   return request.post(args.idamApiUrl + endpoint, options);
 };
 
-const removeUser = args => {
+const removeUser = (args, proxy) => {
   const endpoint = args.accountsEndpoint || '/testing-support/accounts';
   const email = args.testEmail || 'testUser@example.com';
 
-  return request.delete(`${args.idamApiUrl + endpoint}/${email}`);
+  let options = {};
+  if (proxy) {
+    options = setupProxy(proxy);
+  }
+
+  return request.delete(`${args.idamApiUrl + endpoint}/${email}`, options);
 };
 
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1161,6 +1161,18 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
+ip-address@~5.8.0:
+  version "5.8.9"
+  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-5.8.9.tgz#6379277c23fc5adb20511e4d23ec2c1bde105dfd"
+  dependencies:
+    jsbn "1.1.0"
+    lodash.find "^4.6.0"
+    lodash.max "^4.0.1"
+    lodash.merge "^4.6.0"
+    lodash.padstart "^4.6.1"
+    lodash.repeat "^4.1.0"
+    sprintf-js "1.1.0"
+
 ip@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.0.1.tgz#c7e356cdea225ae71b36d70f2e71a92ba4e42590"
@@ -1289,6 +1301,10 @@ js-yaml@3.x, js-yaml@^3.9.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+jsbn@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-1.1.0.tgz#b01307cb29b618a1ed26ec79e911f803c4da0040"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -1381,13 +1397,29 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
+lodash.find@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
+lodash.max@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.max/-/lodash.max-4.0.1.tgz#8735566c618b35a9f760520b487ae79658af136a"
+
 lodash.merge@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.1.tgz#adc25d9cb99b9391c59624f379fbba60d7111d54"
+
+lodash.padstart@^4.6.1:
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.padstart/-/lodash.padstart-4.6.1.tgz#d2e3eebff0d9d39ad50f5cbd1b52a7bce6bb611b"
+
+lodash.repeat@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.repeat/-/lodash.repeat-4.1.0.tgz#fc7de8131d8c8ac07e4b49f74ffe829d1f2bec44"
 
 lodash@^3.10.1:
   version "3.10.1"
@@ -2187,6 +2219,18 @@ socks-proxy-agent@2:
     extend "3"
     socks "~1.1.5"
 
+socks5-client@~1.2.3:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/socks5-client/-/socks5-client-1.2.6.tgz#05b7d695bcdce56d2cbcde2c8d731c20cf87a253"
+  dependencies:
+    ip-address "~5.8.0"
+
+socks5-https-client@^1.0.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/socks5-https-client/-/socks5-https-client-1.2.1.tgz#c8d4a000e39cdc1651d90245af04a735d75d8b09"
+  dependencies:
+    socks5-client "~1.2.3"
+
 socks@1.1.9:
   version "1.1.9"
   resolved "https://registry.yarnpkg.com/socks/-/socks-1.1.9.tgz#628d7e4d04912435445ac0b6e459376cb3e6d691"
@@ -2241,6 +2285,10 @@ spdx-expression-parse@~1.0.0:
 spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
+
+sprintf-js@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.0.tgz#cffcaf702daf65ea39bb4e0fa2b299cec1a1be46"
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
IDAM Test Harness fails to create or remove users if done locally, as the requests are attempted without proxy. This is because CodeceptJS is passed a proxy via its own parameters --proxy-server and this won't be passed through to the IDAM test harness.