### PR TITLE
Remove setting role on pin user

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hmcts/div-idam-test-harness",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Test harness for the IdAM Express Middleware",
   "license": "MIT",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -158,8 +158,7 @@ const getToken = (args, proxy) => {
 const generatePin = (args, proxy) => {
   const requestBody = {
     firstName: args.firstName || 'first-name',
-    lastName: args.lastName || 'last-name',
-    roles: args.roles || []
+    lastName: args.lastName || 'last-name'
   };
   const endpoint = args.generatePinEndpoint || '/pin';
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -306,8 +306,7 @@ describe('test harness unit tests', () => {
       const extendedArgs = Object.assign({}, args, {
         generatePinEndpoint: '/some-pin-endpoint',
         firstName: 'some-first-name',
-        lastName: 'some-last-name',
-        roles: ['123']
+        lastName: 'some-last-name'
       });
 
       postStub.returns('success');


### PR DESCRIPTION
As seen in the definition for pin request:
https://github.com/hmcts/idam-api-spec/blob/master/src/main/resources/api.yaml#L1406

There is no role setting.