### PR TITLE
DIV-6836: Removing userGroup attribute

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -57,13 +57,11 @@ const setupProxy = proxy => {
 
 const createUser = (args, proxy) => {
   const endpoint = args.accountsEndpoint || '/testing-support/accounts';
-  const userGroup = args.testGroupCode || 'divorce-private-beta';
   // Minimum required fields
   const user = {
     email: args.testEmail || 'testUser@example.com',
     forename: args.testForename || 'Test',
     surname: args.testSurname || 'User',
-    userGroup: { code: userGroup },
     password: args.testPassword || 'passWord123!',
     levelOfAccess: args.testLevelOfAccess || '1',
     roles: args.roles || []

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -126,7 +126,7 @@ describe('test harness unit tests', () => {
 
       const expectedOptions = {
         headers: { 'Content-Type': 'application/json' },
-        body: '{"email":"testUser@example.com","forename":"Test","surname":"User","userGroup":{"code":"test"},"password":"passWord123!","levelOfAccess":"1","roles":[]}',
+        body: '{"email":"testUser@example.com","forename":"Test","surname":"User","password":"passWord123!","levelOfAccess":"1","roles":[]}',
         strictSSL: false,
         agentClass: socksAgent,
         socksHost: 'proxyhost',
@@ -148,7 +148,7 @@ describe('test harness unit tests', () => {
 
       const expectedOptions = {
         headers: { 'Content-Type': 'application/json' },
-        body: '{"email":"testUser@example.com","forename":"Test","surname":"User","userGroup":{"code":"test"},"password":"passWord123!","levelOfAccess":"1","roles":["role1","role2"]}',
+        body: '{"email":"testUser@example.com","forename":"Test","surname":"User","password":"passWord123!","levelOfAccess":"1","roles":["role1","role2"]}',
         proxy: 'http://proxyhost:8080/'
       };
 


### PR DESCRIPTION
#### Change description

According to the IDAM team, this is an attribute that's no longer needed. 
Roles are added as part of the "roles" attribute and having this "userGroup" attribute actually makes the creation of users a lot slower.

#### Work checklist

- [ ] Commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added if needed
- [ ] Tests have been updated / new tests has been added if needed
